### PR TITLE
setting up webpack config file to run the npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "webpack-dev-server --entry ./src/js/main.js --output-filename ./dist/bundle.js --open",
-    "build": "webpack src/js/main.js --output dist/bundle.js --open"
+    "start": "webpack-dev-server  --open",
+    "build": "webpack"
   },
   "repository": {
     "type": "git",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,11 @@
+//here we will tell webpack where to start. by setting up entry point
+var path = require('path');
+
+module.exports = {
+    entry: './src/js/main.js',
+    output: {
+        path: path.resolve(__dirname, 'dist'),
+        filename : 'bundle.js',
+        publicPath: '/dist'
+    }
+}


### PR DESCRIPTION
Here, we will set up our first Webpack config fille where we will specify our configuration. 
-- entry: './src/js/main.js' -- > this is our entry point where webpack will access all the required files. 
--  output: {
        path: path.resolve(__dirname, 'dist'),
        filename : 'bundle.js',
        publicPath: '/dist'
    } --> here we need to require node path, then path.resolve will resolve into aboslute paths.
-- then the files will be bundled into bundle.js and will be placed into publicPath under "/dist"